### PR TITLE
Read client version from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 .mypy_cache/
 
 metricq_source_ipmi/test_conf.py
+
+# created by setuptools_scm
+metricq_source_ipmi/source/version.py

--- a/metricq_source_ipmi/source/__init__.py
+++ b/metricq_source_ipmi/source/__init__.py
@@ -1,1 +1,7 @@
 from .main import run
+from .version import version as __version__
+
+__all__ = [
+    "run",
+    "__version__",
+]

--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -455,6 +455,7 @@ class IpmiSource(metricq.IntervalSource):
                     config.get('interval', 1),
                 )
             )
+        results = []
         if jobs:
             results = await asyncio.gather(*jobs)
         all_metrics = {}
@@ -481,7 +482,7 @@ class IpmiSource(metricq.IntervalSource):
         logger.debug("Set up new collection loops")
 
         self.log_loop = asyncio.ensure_future(
-            log_loop(complete_conf, log_interval=conf.get("log_interval", 30))
+            log_loop(complete_conf, log_interval=config.get("log_interval", 30))
         )
         logger.debug("Set up new log loop")
 

--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -12,6 +12,7 @@ import click_log
 
 import metricq
 from metricq.logging import get_logger
+from .version import version as client_version
 import hostlist
 
 IPMI_SENSORS = 'ipmi-sensors'
@@ -508,9 +509,10 @@ class IpmiSource(metricq.IntervalSource):
 @click.command()
 @click.option('--server', default='amqp://localhost/')
 @click.option('--token', default='source-ipmi')
+@click.version_option(client_version)
 @click_log.simple_verbosity_option(logger)
 def run(server, token):
-    src = IpmiSource(token=token, management_url=server)
+    src = IpmiSource(token=token, management_url=server, client_version=client_version)
     src.run()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]~=5.0"]
+build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.setuptools_scm]
+write_to = "metricq_source_ipmi/source/version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,16 @@
 from setuptools import setup
 
-setup(name='metricq_source_ipmi',
-      version='0.1',
-      author='TU Dresden',
-      python_requires=">=3.6",
-      packages=['metricq_source_ipmi.source', 'metricq_source_ipmi.plugin_hyc_tenant'],
-      scripts=[],
-      entry_points='''
+setup(
+    name="metricq_source_ipmi",
+    version="0.1",
+    author="TU Dresden",
+    python_requires=">=3.6",
+    packages=["metricq_source_ipmi.source", "metricq_source_ipmi.plugin_hyc_tenant"],
+    scripts=[],
+    entry_points="""
       [console_scripts]
       metricq-source-ipmi=metricq_source_ipmi.source:run
-      ''',
-      install_requires=['aiomonitor', 'click', 'click_log', 'metricq', 'python-hostlist'])
+      """,
+    install_requires=["aiomonitor", "click", "click_log", "metricq", "python-hostlist"],
+    use_scm_version=True,
+)


### PR DESCRIPTION
Read the project version from `git` using `setuptools_scm` and use it as `client_version` in `discover`-RPC responses.
Add a `--version` option to the script to quickly view the client version.

This also fixes access to an unbound variable when an empty config is provided.