### PR TITLE
Upgrade to metricq version 2.0

### DIFF
--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -11,7 +11,9 @@ import click
 import click_log
 
 import metricq
+from metricq import Timedelta
 from metricq.logging import get_logger
+
 from .version import version as client_version
 import hostlist
 
@@ -441,7 +443,7 @@ class IpmiSource(metricq.IntervalSource):
 
     @metricq.rpc_handler('config')
     async def _on_config(self, **config):
-        self.period = 1
+        self.period = Timedelta.from_s(1)
         jobs = []
         global CMD_IPMI_SENSORE_BASE
         CMD_IPMI_SENSORE_BASE = build_cmd_ipmi_base(

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,12 @@ setup(
       [console_scripts]
       metricq-source-ipmi=metricq_source_ipmi.source:run
       """,
-    install_requires=["aiomonitor", "click", "click_log", "metricq", "python-hostlist"],
+    install_requires=[
+        "aiomonitor",
+        "click",
+        "click_log",
+        "metricq ~= 2.0",
+        "python-hostlist",
+    ],
     use_scm_version=True,
 )


### PR DESCRIPTION
`IntervalSource.period` is now a Timedelta; explicitly set a source period of 1 second.

Other than that, there seem to be no breaking changes that affect this source.  Full upgrading instruction can be found [here](https://metricq.github.io/metricq-python/upgrading.html#x-2-0), in case I missed something.