### PR TITLE
Support hosts with mixed record_ids

### DIFF
--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -90,12 +90,6 @@ async def get_sensor_data_dict(hosts, username, password, record_ids=None):
         password,
         record_ids=record_ids,
     )
-    if "Sensor Record ID" in data and "not found" in data:
-        ts, data = await ipmi_sensors(
-            hosts,
-            username,
-            password
-        )
 
     data_dict = {}
     for elem in data.splitlines():
@@ -133,9 +127,10 @@ async def try_fix_hosts(conf, hosts_to_fix):
         for metric_sufix, metric_data in conf['metrics'].items():
             for sensor in metric_data['sensors']:
                 try:
-                    conf['record_ids'].add(
-                        data[sensor][host]['record_id'],
-                    )
+                    if conf['record_ids'] != None:
+                        conf['record_ids'].add(
+                            data[sensor][host]['record_id'],
+                        )
                 except KeyError:
                     conf['hosts'][host]['next_try'] = now + \
                         RETRY_INTERVALS[
@@ -308,7 +303,7 @@ async def create_conf_and_metrics(conf_part, default_interval):
         interval = conf_part.get('interval', default_interval)
         new_conf = {
             'metrics': {},
-            'record_ids': set(),
+            'record_ids': conf_part['record_ids'] if 'record_ids' in conf_part.keys() else set(),
             'hosts': {},
             # 'active_hosts' serves for performance.
             # That not always an additional loop has to be made to check who is active.
@@ -370,9 +365,10 @@ async def create_conf_and_metrics(conf_part, default_interval):
             for host, host_name in zip(hosts, host_names):
                 for sensor in new_conf['metrics'][metric_sufix]['sensors']:
                     try:
-                        new_conf['record_ids'].add(
-                            queried_sensor_data[sensor][host]['record_id'],
-                        )
+                        if new_conf['record_ids'] != None:
+                            new_conf['record_ids'].add(
+                                queried_sensor_data[sensor][host]['record_id'],
+                            )
                     except KeyError:
                         new_conf['hosts'][host]['status'] = Status.ERROR
                         if host in new_conf['active_hosts']:

--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -90,6 +90,12 @@ async def get_sensor_data_dict(hosts, username, password, record_ids=None):
         password,
         record_ids=record_ids,
     )
+    if "Sensor Record ID" in data and "not found" in data:
+        ts, data = await ipmi_sensors(
+            hosts,
+            username,
+            password
+        )
 
     data_dict = {}
     for elem in data.splitlines():

--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -303,7 +303,7 @@ async def create_conf_and_metrics(conf_part, default_interval):
         interval = conf_part.get('interval', default_interval)
         new_conf = {
             'metrics': {},
-            'record_ids': conf_part['record_ids'] if 'record_ids' in conf_part.keys() else set(),
+            'record_ids': None if conf_part.get('disable_record_ids', False) else set(),
             'hosts': {},
             # 'active_hosts' serves for performance.
             # That not always an additional loop has to be made to check who is active.

--- a/metricq_source_ipmi/source/main.py
+++ b/metricq_source_ipmi/source/main.py
@@ -127,7 +127,7 @@ async def try_fix_hosts(conf, hosts_to_fix):
         for metric_sufix, metric_data in conf['metrics'].items():
             for sensor in metric_data['sensors']:
                 try:
-                    if conf['record_ids'] != None:
+                    if conf['record_ids'] is not None:
                         conf['record_ids'].add(
                             data[sensor][host]['record_id'],
                         )
@@ -365,7 +365,7 @@ async def create_conf_and_metrics(conf_part, default_interval):
             for host, host_name in zip(hosts, host_names):
                 for sensor in new_conf['metrics'][metric_sufix]['sensors']:
                     try:
-                        if new_conf['record_ids'] != None:
+                        if new_conf['record_ids'] is not None:
                             new_conf['record_ids'].add(
                                 queried_sensor_data[sensor][host]['record_id'],
                             )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1",
     author="TU Dresden",
     python_requires=">=3.10",
-    packages=["metricq_source_ipmi.source", "metricq_source_ipmi.plugin_hyc_tenant"],
+    packages=["metricq_source_ipmi.source", "metricq_source_ipmi.plugin_hyc_tenant", "metricq_source_ipmi.plugin_power_supply"],
     scripts=[],
     entry_points="""
       [console_scripts]


### PR DESCRIPTION
This PR adds a workaround for the issue that different hosts use different record_ids for the same entities. In particular, it adds a new config boolean option `disable_record_ids`. This settings allows to disable the usage of record_ids, allowing the mixed setups with a trade-off to performance.